### PR TITLE
Call ufw enable with --force option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@ class ufw {
   }
 
   exec { 'ufw-enable':
-    command => 'yes | ufw enable',
+    command => 'ufw --force enable',
     unless  => 'ufw status | grep "Status: active"',
   }
 


### PR DESCRIPTION
Instead of piping the output of 'yes', use the --force option to disable
the prompt.
