### PR TITLE
Fix $from_match: protocol is not listed in source

### DIFF
--- a/manifests/allow.pp
+++ b/manifests/allow.pp
@@ -11,7 +11,7 @@ define ufw::allow($proto='tcp', $port='all', $ip='', $from='any') {
 
   $from_match = $from ? {
     'any'   => 'Anywhere',
-    default => "$from/$proto",
+    default => "$from",
   }
 
   exec { "ufw-allow-${proto}-from-${from}-to-${ipadr}-port-${port}":

--- a/manifests/deny.pp
+++ b/manifests/deny.pp
@@ -11,7 +11,7 @@ define ufw::deny($proto='tcp', $port='all', $ip='', $from='any') {
 
   $from_match = $from ? {
     'any'   => 'Anywhere',
-    default => "$from/$proto",
+    default => "$from",
   }
 
   exec { "ufw-deny-${proto}-from-${from}-to-${ipadr}-port-${port}":


### PR DESCRIPTION
The protocol is not listed in the output of `ufw status`. This fixes
ufw::allow and ufw::deny to only execute once when a `from` parameter is
specified.
