### PR TITLE
Added support to control the logging of ufw

### DIFF
--- a/manifests/logging.pp
+++ b/manifests/logging.pp
@@ -1,0 +1,8 @@
+define ufw::logging($level='low') {
+
+  exec { "ufw-logging-${level}":
+    command => "ufw logging $level",
+    require => Exec['ufw-default-deny'],
+    before  => Exec['ufw-enable'],
+  }
+}


### PR DESCRIPTION
Some of our servers were crashing when the logging was not turned off, with this patch we are able to turn the logging off for these machines like this:

  include ufw

  ufw::logging { "prevent-logging":
    level => 'off',
  }
