### PR TITLE
simplify module usage by qualifying exec ourselves

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,6 @@ will be enabled, and all incomming connections will be denied:
 include ufw
 ```
 
-Note that you'll need to define a global search path for the `exec`
-resource to make this module function properly. This should ideally be
-placed in `manifests/site.pp`:
-
-```puppet
-Exec {
-  path => "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-}
-```
-
 You can then allow certain connections:
 
 ```puppet

--- a/manifests/allow.pp
+++ b/manifests/allow.pp
@@ -27,9 +27,11 @@ define ufw::allow($proto='tcp', $port='all', $ip='', $from='any') {
   }
 
   exec { "ufw-allow-${proto}-from-${from}-to-${ipadr}-port-${port}":
-    command => $command,
-    unless  => $unless,
-    require => Exec['ufw-default-deny'],
-    before  => Exec['ufw-enable'],
+    command  => $command,
+    path     => '/usr/sbin:/bin:/usr/bin',
+    provider => 'posix',
+    unless   => $unless,
+    require  => Exec['ufw-default-deny'],
+    before   => Exec['ufw-enable'],
   }
 }

--- a/manifests/deny.pp
+++ b/manifests/deny.pp
@@ -26,9 +26,11 @@ define ufw::deny($proto='tcp', $port='all', $ip='', $from='any') {
   }
 
   exec { "ufw-deny-${proto}-from-${from}-to-${ipadr}-port-${port}":
-    command => $command,
-    unless  => $unless,
-    require => Exec['ufw-default-deny'],
-    before  => Exec['ufw-enable'],
+    command  => $command,
+    path     => '/usr/sbin:/bin:/usr/bin',
+    provider => 'posix',
+    unless   => $unless,
+    require  => Exec['ufw-default-deny'],
+    before   => Exec['ufw-enable'],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,12 @@
 #  Careful calling this class alone, was it will by default
 #  enable ufw, and disable all incoming traffic.
 class ufw {
+
+  Exec {
+    path     => '/usr/sbin:/bin:/usr/bin',
+    provider => 'posix',
+  }
+
   package { 'ufw':
     ensure => present,
   }

--- a/manifests/limit.pp
+++ b/manifests/limit.pp
@@ -3,9 +3,12 @@
 #   enable connection rate limiting for this $proto
 #
 define ufw::limit($proto='tcp') {
+
   exec { "ufw limit ${name}/${proto}":
-    unless  => "ufw status | grep -qE '^${name}/${proto} +LIMIT +Anywhere'",
-    require => Exec['ufw-default-deny'],
-    before  => Exec['ufw-enable'],
+    path     => '/usr/sbin:/bin:/usr/bin',
+    provider => 'posix',
+    unless   => "ufw status | grep -qE '^${name}/${proto} +LIMIT +Anywhere'",
+    require  => Exec['ufw-default-deny'],
+    before   => Exec['ufw-enable'],
   }
 }

--- a/manifests/logging.pp
+++ b/manifests/logging.pp
@@ -5,8 +5,10 @@
 define ufw::logging($level='low') {
 
   exec { "ufw-logging-${level}":
-    command => "ufw logging ${level}",
-    require => Exec['ufw-default-deny'],
-    before  => Exec['ufw-enable'],
+    command  => "ufw logging ${level}",
+    path     => '/usr/sbin:/bin:/usr/bin',
+    provider => 'posix',
+    require  => Exec['ufw-default-deny'],
+    before   => Exec['ufw-enable'],
   }
 }

--- a/manifests/reject.pp
+++ b/manifests/reject.pp
@@ -15,15 +15,17 @@ define ufw::reject($proto='tcp', $port='all', $ip='', $from='any') {
   }
 
   exec { "ufw-reject-${proto}-from-${from}-to-${ipadr}-port-${port}":
-    command => $port ? {
+    path     => '/usr/sbin:/bin:/usr/bin',
+    provider => 'posix',
+    command  => $port ? {
       'all'   => "ufw reject proto $proto from $from to $ipadr",
       default => "ufw reject proto $proto from $from to $ipadr port $port",
     },
-    unless  => $port ? {
+    unless   => $port ? {
       'all'   => "ufw status | grep -qE \"^${ipadr}/${proto} +REJECT +${from_match}$\"",
       default => "ufw status | grep -qEe \"^${ipadr} ${port}/${proto} +REJECT +${from_match}$\" -qe \"^${port}/${proto} +REJECT +${from_match}$\"",
     },
-    require => Exec['ufw-default-deny'],
-    before  => Exec['ufw-enable'],
+    require  => Exec['ufw-default-deny'],
+    before   => Exec['ufw-enable'],
   }
 }

--- a/tests/allow.pp
+++ b/tests/allow.pp
@@ -1,7 +1,3 @@
-Exec {
-  path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-}
-
 ufw::allow{ 'allow-all-from-trusted':
   proto => 'udp',
   port  => 80,

--- a/tests/deny.pp
+++ b/tests/deny.pp
@@ -1,7 +1,3 @@
-Exec {
-  path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-}
-
 ufw::deny{ 'allow-all-from-trusted':
   proto => 'udp',
   port  => 80,

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,5 +1,1 @@
-Exec {
-  path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-}
-
 class { 'ufw': }

--- a/tests/limit.pp
+++ b/tests/limit.pp
@@ -1,5 +1,1 @@
-Exec {
-  path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-}
-
 ufw::limit { '22': }

--- a/tests/reject.pp
+++ b/tests/reject.pp
@@ -1,7 +1,3 @@
-Exec {
-  path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-}
-
 ufw::reject{ 'reject-all-from-trusted':
   proto => 'udp',
   port  => 80,


### PR DESCRIPTION
The ufw class as well as all the defined types now declare a sensible
defaults for Exec:

```
path     => '/usr/sbin:/bin:/usr/bin',
provider => 'posix',
```

Now users can simply /use/ the class. The tests/ are adapted to
reflect this, as is the documentation.
