### PR TITLE
Adding Hiera resource creation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,11 +4,11 @@
 #  Careful calling this class alone, was it will by default
 #  enable ufw, and disable all incoming traffic.
 class ufw(
-  $ufw_allows   = {},
-  $ufw_denies   = {},
-  $ufw_limits   = {},
-  $ufw_loggings = {},
-  $ufw_rejects  = {},
+  $allows   = {},
+  $denies   = {},
+  $limits   = {},
+  $loggings = {},
+  $rejects  = {},
   ) {
 
   Exec {
@@ -40,9 +40,9 @@ class ufw(
   }
 
   # Hiera resource creation
-  create_resources('ufw::allow', $ufw_allows)
-  create_resources('ufw::deny', $ufw_denies)
-  create_resources('ufw::limit', $ufw_limits)
-  create_resources('ufw::logging', $ufw_loggings)
-  create_resources('ufw::reject', $ufw_rejects)
+  create_resources('ufw::allow', $allows)
+  create_resources('ufw::deny', $denies)
+  create_resources('ufw::limit', $limits)
+  create_resources('ufw::logging', $loggings)
+  create_resources('ufw::reject', $rejects)
 }


### PR DESCRIPTION
For issue #18. Enables Hiera setup via hashes on the parameters:
- `allows`
- `denies`
- `limits`
- `loggings`
- `rejects`

And calling the built-into Puppet `create_resources` function on the respective ufw resources. Backwards compatible (the default empty hashes cause nothing to be created).
