### PR TITLE
Qualify `ufw` commands

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,12 +6,12 @@ class ufw {
   Package['ufw'] -> Exec['ufw-default-deny'] -> Exec['ufw-enable']
 
   exec { 'ufw-default-deny':
-    command => 'ufw default deny',
+    command => '/usr/sbin/ufw default deny',
     unless  => 'ufw status verbose | grep "Default: deny (incoming), allow (outgoing)"',
   }
 
   exec { 'ufw-enable':
-    command => 'ufw --force enable',
+    command => '/usr/sbin/ufw --force enable',
     unless  => 'ufw status | grep "Status: active"',
   }
 


### PR DESCRIPTION
This pull request qualifies the `ufw` commands in order to ensure that they run
without error during a Puppet run. Previously, the command would fail to run as
the exec was unqualified, and Puppet could not find the binary:

```
Error: Parameter unless failed on Exec[ufw-allow-tcp-from-any-to-any-port-22]: 'ufw status | grep -E "22/tcp +ALLOW +Anywhere"' is not qualified and no path was specified. Please qualify the command or specify a path.
```

Puppet refuses to trust that the $PATH of the shell from which a Puppet run is
started is correct. It therefore demands qualified `exec` types.
