### PR TITLE
Limited support for proto => any

### DIFF
--- a/manifests/allow.pp
+++ b/manifests/allow.pp
@@ -14,6 +14,11 @@ define ufw::allow($proto='tcp', $port='all', $ip='', $from='any') {
     default => $from,
   }
 
+  $proto_match = $proto ? {
+    'any'   => '',
+    default => "/${proto}",
+  }
+
   $command = $port ? {
     'all'   => "ufw allow proto ${proto} from ${from} to ${ipadr}",
     default => "ufw allow proto ${proto} from ${from} to ${ipadr} port ${port}",
@@ -21,9 +26,9 @@ define ufw::allow($proto='tcp', $port='all', $ip='', $from='any') {
 
   $unless  = "${ipadr}:${port}" ? {
     'any:all'    => "ufw status | grep -qE '^ +ALLOW +${from_match}$'",
-    /[0-9]:all$/ => "ufw status | grep -qE '^${ipadr}/${proto} +ALLOW +${from_match}$'",
-    /^any:[0-9]/ => "ufw status | grep -qE '^${port}/${proto} +ALLOW +${from_match}$'",
-    default      => "ufw status | grep -qE '^${ipadr} ${port}/${proto} +ALLOW +${from_match}$'",
+    /[0-9]:all$/ => "ufw status | grep -qE '^${ipadr}${proto_match} +ALLOW +${from_match}$'",
+    /^any:[0-9]/ => "ufw status | grep -qE '^${port}${proto_match} +ALLOW +${from_match}$'",
+    default      => "ufw status | grep -qE '^${ipadr} ${port}${proto_match} +ALLOW +${from_match}$'",
   }
 
   exec { "ufw-allow-${proto}-from-${from}-to-${ipadr}-port-${port}":


### PR DESCRIPTION
The proto => any functionality works, however every run attempts to add the rule again because the grep match doesn't find "/any" in the ufw status output.
