### PR TITLE
remove overzealous ^anchor

### DIFF
--- a/manifests/allow.pp
+++ b/manifests/allow.pp
@@ -20,7 +20,7 @@ define ufw::allow($proto='tcp', $port='all', $ip='', $from='any') {
   }
 
   $unless  = "${ipadr}:${port}" ? {
-    'any:all'    => "ufw status | grep -qE '^ +ALLOW +${from_match}$'",
+    'any:all'    => "ufw status | grep -qE ' +ALLOW +${from_match}$'",
     /[0-9]:all$/ => "ufw status | grep -qE '^${ipadr}/${proto} +ALLOW +${from_match}$'",
     /^any:[0-9]/ => "ufw status | grep -qE '^${port}/${proto} +ALLOW +${from_match}$'",
     default      => "ufw status | grep -qE '^${ipadr} ${port}/${proto} +ALLOW +${from_match}$'",

--- a/spec/defines/ufw__allow_spec.rb
+++ b/spec/defines/ufw__allow_spec.rb
@@ -5,7 +5,7 @@ describe 'ufw::allow', :type => :define do
   context 'basic operation' do
     it { should contain_exec('ufw-allow-tcp-from-any-to-any-port-all').
       with_command("ufw allow proto tcp from any to any").
-      with_unless("ufw status | grep -qE '^ +ALLOW +Anywhere$'")
+      with_unless("ufw status | grep -qE ' +ALLOW +Anywhere$'")
     }
   end
 
@@ -13,7 +13,7 @@ describe 'ufw::allow', :type => :define do
     let(:params) { {:from => '192.0.2.42'} }
     it { should contain_exec('ufw-allow-tcp-from-192.0.2.42-to-any-port-all').
       with_command("ufw allow proto tcp from 192.0.2.42 to any").
-      with_unless("ufw status | grep -qE '^ +ALLOW +192.0.2.42$'")
+      with_unless("ufw status | grep -qE ' +ALLOW +192.0.2.42$'")
     }
   end
 


### PR DESCRIPTION
This caused the grep in the unless expression to fail, and hence then
exec to execute every run.

This patch fixes #25
