### PR TITLE
Using hiera_hash to allow for merging of hashes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,11 +4,11 @@
 #  Careful calling this class alone, was it will by default
 #  enable ufw, and disable all incoming traffic.
 class ufw(
-  $allows   = {},
-  $denies   = {},
-  $limits   = {},
-  $loggings = {},
-  $rejects  = {},
+  $allow   = {},
+  $deny    = {},
+  $limit   = {},
+  $logging = {},
+  $reject  = {},
   ) {
 
   Exec {
@@ -40,9 +40,9 @@ class ufw(
   }
 
   # Hiera resource creation
-  create_resources('ufw::allow', hiera_hash('ufw::allows', $allows))
-  create_resources('ufw::deny', hiera_hash('ufw::denies', $denies))
-  create_resources('ufw::limit', hiera_hash('ufw::limits', $limits))
-  create_resources('ufw::logging', hiera_hash('ufw::loggings', $loggings))
-  create_resources('ufw::reject', hiera_hash('ufw::rejects', $rejects))
+  create_resources('ufw::allow', hiera_hash('ufw::allow', $allow))
+  create_resources('ufw::deny', hiera_hash('ufw::deny', $deny))
+  create_resources('ufw::limit', hiera_hash('ufw::limit', $limit))
+  create_resources('ufw::logging', hiera_hash('ufw::logging', $logging))
+  create_resources('ufw::reject', hiera_hash('ufw::reject', $reject))
 }


### PR DESCRIPTION
Wish I'd known about this in my prior PR, but this is a better way to get the values. `hiera_hash` is a built-in function that allows Hiera to merge hashes in the manner specified in the Hiera configuration file. If it can't find the properties (say if Hiera isn't setup), it will default to the parameters.
