### PR TITLE
Add /sbin to Exec path

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,7 @@ class ufw(
   ) {
 
   Exec {
-    path     => '/usr/sbin:/bin:/usr/bin',
+    path     => '/sbin:/usr/sbin:/bin:/usr/bin',
     provider => 'posix',
   }
 


### PR DESCRIPTION
This caused the unless expression to fail for 'ufw-default-deny' in
Ubuntu 14.04, resulting in an exec on every puppet run.

This patch fixes issue #28
