### PR TITLE
Support ipv6 output from ufw status.

### DIFF
--- a/manifests/allow.pp
+++ b/manifests/allow.pp
@@ -9,8 +9,16 @@ define ufw::allow($proto='tcp', $port='all', $ip='', $from='any') {
     default => $ip,
   }
 
+  $ipver = $ipadr ? {
+    /:/     => 'v6',
+    default => 'v4',
+  }
+
   $from_match = $from ? {
-    'any'   => 'Anywhere',
+    'any'   => $ipver ? {
+      'v4' => 'Anywhere',
+      'v6' => 'Anywhere \(v6\)',
+      },
     default => $from,
   }
 

--- a/spec/defines/ufw__allow_spec.rb
+++ b/spec/defines/ufw__allow_spec.rb
@@ -34,6 +34,13 @@ describe 'ufw::allow', :type => :define do
       }
     end
 
+    context 'from $ip parameter (ipv6)' do
+      let(:params) { {:ip => '2a00:1450:4009:80c::1001'} }
+      it { should contain_exec('ufw-allow-tcp-from-any-to-2a00:1450:4009:80c::1001-port-all').
+        with_command("ufw allow proto tcp from any to 2a00:1450:4009:80c::1001").
+        with_unless("ufw status | grep -qE '^2a00:1450:4009:80c::1001/tcp +ALLOW +Anywhere \\(v6\\)$'")
+      }
+    end
     context 'when both $ip and ipaddress_eth0 are specified' do
       let(:facts) { {:ipaddress_eth0 => '192.0.2.67'} }
       let(:params) { {:ip => '192.0.2.68'} }


### PR DESCRIPTION
The output from ufw status for an ipv6 from any rule adds `(v6)` to the end of the line

```
$ sudo ufw status
Status: active

To                         Action      From
--                         ------      ----
22/tcp                     ALLOW       Anywhere
22/tcp                     ALLOW       Anywhere (v6)
```

This causes an ipv6 from any rule to be execed on each puppet run.

This commit works out if the ip provided is ipv6 or not and then changes the regex for the unless.
