### PR TITLE
add forward parameter to baseclass, default DROP

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ will be enabled, and all incomming connections will be denied:
 include ufw
 ```
 
+You can change the forward policy, which defaults to `DROP`:
+
+```puppet
+class { 'ufw':
+  forward => 'ACCEPT',
+}
+```
+
 You can then allow certain connections:
 
 ```puppet

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,10 @@ class ufw(
   $limit   = {},
   $logging = {},
   $reject  = {},
-  ) {
+  $forward = 'DROP',
+) {
+
+  validate_re($forward, 'ACCEPT|DROP|REJECT')
 
   Exec {
     path     => '/sbin:/usr/sbin:/bin:/usr/bin',
@@ -40,6 +43,13 @@ class ufw(
         unless  => 'ufw status | grep "Status: active"',
       }
     }
+  }
+
+  file_line { 'forward policy':
+    path   => '/etc/default/ufw',
+    line   => "DEFAULT_FORWARD_POLICY=\"${forward}\"",
+    match  => '^DEFAULT_FORWARD_POLICY=',
+    notify => Service['ufw'],
   }
 
   service { 'ufw':


### PR DESCRIPTION
ufw's /etc/default/ufw allows to tweak some parameters: among others is
the forward policy. it can useful to set that policy to something
other than DROP.
this addresses #35
