### PR TITLE
Service restart

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,8 @@ class ufw(
     ensure    => running,
     enable    => true,
     hasstatus => true,
+    path      => '/bin:/sbin:/usr/bin:/usr/sbin',
+    restart   => 'ufw disable && ufw --force enable',
     subscribe => Package['ufw'],
   }
 


### PR DESCRIPTION
Changed service restart command; the default restart (something like `service ufw restart`) doesn't actually reload the service. If you make any changes to ufw config files and then notify the UFW service in this module, changes will not be activated. Using this patch, ufw will be forced to restart and load any changed config files.