### PR TITLE
Fixed ufw rules being reapplied every time on Ubuntu 16.04 LTS

### DIFF
--- a/manifests/allow.pp
+++ b/manifests/allow.pp
@@ -37,10 +37,10 @@ define ufw::allow($proto='tcp', $port='all', $ip='', $from='any') {
   }
 
   $unless  = "${ipadr}:${port}" ? {
-    'any:all'    => "ufw status | grep -qE ' +ALLOW +${from_match}$'",
-    /[0-9]:all$/ => "ufw status | grep -qE '^${ipadr}${proto_match} +ALLOW +${from_match}${from_proto_match}$'",
-    /^any:[0-9]/ => "ufw status | grep -qE '^${port}${proto_match} +ALLOW +${from_match}$'",
-    default      => "ufw status | grep -qE '^${ipadr} ${port}${proto_match} +ALLOW +${from_match}$'",
+    'any:all'    => "ufw status | grep -qE ' +ALLOW +${from_match}( +.*)?$'",
+    /[0-9]:all$/ => "ufw status | grep -qE '^${ipadr}${proto_match} +ALLOW +${from_match}${from_proto_match}( +.*)?$'",
+    /^any:[0-9]/ => "ufw status | grep -qE '^${port}${proto_match} +ALLOW +${from_match}( +.*)?$'",
+    default      => "ufw status | grep -qE '^${ipadr} ${port}${proto_match} +ALLOW +${from_match}( +.*)?$'",
   }
 
   exec { "ufw-allow-${proto}-from-${from}-to-${ipadr}-port-${port}":

--- a/manifests/deny.pp
+++ b/manifests/deny.pp
@@ -27,7 +27,7 @@ define ufw::deny($proto='tcp', $port='all', $ip='', $from='any') {
 
   $unless    = $port ? {
     'all'   => "ufw status | grep -qE '${ipadr}/${proto} +DENY +${from_match}'",
-    default => "ufw status | grep -qEe '^${ipadr} ${port}/${proto} +DENY +${from_match}$' -qe '^${port}/${proto} +DENY +${from_match}$'",
+    default => "ufw status | grep -qEe '^${ipadr} ${port}/${proto} +DENY +${from_match}( +.*)?$' -qe '^${port}/${proto} +DENY +${from_match}( +.*)?$'",
   }
 
   exec { "ufw-deny-${proto}-from-${from}-to-${ipadr}-port-${port}":

--- a/manifests/reject.pp
+++ b/manifests/reject.pp
@@ -25,8 +25,8 @@ define ufw::reject($proto='tcp', $port='all', $ip='', $from='any') {
   }
 
   $unless   = $port ? {
-    'all'   => "ufw status | grep -qE '^${ipadr}/${proto} +REJECT +${from_match}$'",
-    default => "ufw status | grep -qEe '^${ipadr} ${port}/${proto} +REJECT +${from_match}$' -qe '^${port}/${proto} +REJECT +${from_match}$'",
+    'all'   => "ufw status | grep -qE '^${ipadr}/${proto} +REJECT +${from_match}( +.*)?$'",
+    default => "ufw status | grep -qEe '^${ipadr} ${port}/${proto} +REJECT +${from_match}( +.*)?$' -qe '^${port}/${proto} +REJECT +${from_match}( +.*)?$'",
   }
 
   exec { "ufw-reject-${proto}-from-${from}-to-${ipadr}-port-${port}":


### PR DESCRIPTION
allow.pp, deny.pp, reject.pp: Fixed the grep statement to accommodate for the 'comment' option added to ufw 0.35