### PR TITLE
Add an `ensure` parameter to ufw::allow

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,5 +74,16 @@ ufw::logging { "prevent-logging":
 }
 ```
 
+To delete a single rule, add `ensure => absent` to the allow.
+```puppet
+ufw::allow { "allow-ssh-from-all":
+  ensure => absent,
+  port   => 22,
+}
+```
+Like most Puppet resources, allow this to successfully run on all your machines
+at least once before removing it, in order to assure that the rule is gone.
+
+
 ## Known Limitations ##
 Currently it is not possible to purge unmanaged rules and remove defined rules this will need to be done manually. (see #21 )

--- a/manifests/allow.pp
+++ b/manifests/allow.pp
@@ -1,5 +1,11 @@
 # Define ufw::allow
-define ufw::allow($proto='tcp', $port='all', $ip='', $from='any') {
+define ufw::allow(
+  $proto='tcp',
+  $port='all',
+  $ip='',
+  $from='any',
+  $ensure='present',
+) {
 
   if $ip == '' {
     $ipadr = pick($::ipaddress_eth0, $::ipaddress, 'any')
@@ -17,7 +23,7 @@ define ufw::allow($proto='tcp', $port='all', $ip='', $from='any') {
     'any'   => $ipver ? {
       'v4' => 'Anywhere',
       'v6' => 'Anywhere \(v6\)',
-      },
+    },
     default => $from,
   }
 
@@ -31,24 +37,42 @@ define ufw::allow($proto='tcp', $port='all', $ip='', $from='any') {
     default => $proto_match,
   }
 
-  $command = $port ? {
-    'all'   => "ufw allow proto ${proto} from ${from} to ${ipadr}",
-    default => "ufw allow proto ${proto} from ${from} to ${ipadr} port ${port}",
+  $grep_existing_rule = "${ipadr}:${port}" ? {
+    'any:all'    => "grep -qE ' +ALLOW +${from_match}$'",
+    /[0-9]:all$/ => "grep -qE '^${ipadr}${proto_match} +ALLOW +${from_match}${from_proto_match}$'",
+    /^any:[0-9]/ => "grep -qE '^${port}${proto_match} +ALLOW +${from_match}$'",
+    default      => "grep -qE '^${ipadr} ${port}${proto_match} +ALLOW +${from_match}$'",
   }
 
-  $unless  = "${ipadr}:${port}" ? {
-    'any:all'    => "ufw status | grep -qE ' +ALLOW +${from_match}$'",
-    /[0-9]:all$/ => "ufw status | grep -qE '^${ipadr}${proto_match} +ALLOW +${from_match}${from_proto_match}$'",
-    /^any:[0-9]/ => "ufw status | grep -qE '^${port}${proto_match} +ALLOW +${from_match}$'",
-    default      => "ufw status | grep -qE '^${ipadr} ${port}${proto_match} +ALLOW +${from_match}$'",
+  $rule = $port ? {
+    'all'   => "allow proto ${proto} from ${from} to ${ipadr}",
+    default => "allow proto ${proto} from ${from} to ${ipadr} port ${port}",
   }
 
-  exec { "ufw-allow-${proto}-from-${from}-to-${ipadr}-port-${port}":
-    command  => $command,
-    path     => '/usr/sbin:/bin:/usr/bin',
-    provider => 'posix',
-    unless   => $unless,
-    require  => Exec['ufw-default-deny'],
-    before   => Exec['ufw-enable'],
+  if $ensure == 'absent' {
+    $command = "ufw delete ${rule}"
+    $onlyif = "ufw status | ${grep_existing_rule}"
+
+    exec { "ufw-delete-${proto}-from-${from}-to-${ipadr}-port-${port}":
+      command  => $command,
+      path     => '/usr/sbin:/bin:/usr/bin',
+      provider => 'posix',
+      onlyif   => $onlyif,
+      require  => Exec['ufw-default-deny'],
+      before   => Exec['ufw-enable'],
+    }
+  }
+  else {
+    $command = "ufw ${rule}"
+    $unless = "ufw status | ${grep_existing_rule}"
+
+    exec { "ufw-allow-${proto}-from-${from}-to-${ipadr}-port-${port}":
+      command  => $command,
+      path     => '/usr/sbin:/bin:/usr/bin',
+      provider => 'posix',
+      unless   => $unless,
+      require  => Exec['ufw-default-deny'],
+      before   => Exec['ufw-enable'],
+    }
   }
 }

--- a/spec/defines/ufw__allow_spec.rb
+++ b/spec/defines/ufw__allow_spec.rb
@@ -68,4 +68,12 @@ describe 'ufw::allow', :type => :define do
       with_unless("ufw status | grep -qE '^8080/tcp +ALLOW +Anywhere$'")
     }
   end
+
+  context 'with ensure => absent' do
+    let(:params) { {:ensure => 'absent'} }
+    it { should contain_exec('ufw-delete-tcp-from-any-to-any-port-all').
+      with_command("ufw delete allow proto tcp from any to any").
+      with_onlyif("ufw status | grep -qE ' +ALLOW +Anywhere$'")
+    }
+  end
 end


### PR DESCRIPTION
Adds an `ensure` parameter to `ufw::allow`, which currently defaults to
`present`, and can accept `absent`. When set to `absent`, the rule will
get deleted (if it exists) rather than created. Needing to delete a
single rule across several hundred machines is a pain, and this feels
like a good step with rule purging is figured out.  This partially
addresses the lack of purging unused rules, though this is a 'manual`
delete rather than an entire purge.

Related to #21