### PR TITLE
Fix specs by removing STRICT_VARIABLES=yes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ matrix:
   - rvm: 2.1.5
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 2.1.6
-    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
+    env: PUPPET_GEM_VERSION="~> 4.0"


### PR DESCRIPTION
Puppet 4 deprecated the ipaddress_eth0 fact, and moved it to
`$facts['networking']['interfaces']['eth0']['ip']`. Facter will still
resolve it at runtime, but STRICT_VARIABLES sees it as being gone, so to
continue to satisfy backwards compatibility, we should remove
STRICT_VARIABLES from the test run.