### PR TITLE
regression: allow/deny/reject *any* protocol

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
-require 'puppet-strings/rake_tasks'
+require 'puppet-strings/tasks'
 
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('relative')

--- a/manifests/allow.pp
+++ b/manifests/allow.pp
@@ -25,7 +25,7 @@ define ufw::allow(
 ) {
   validate_re($direction, 'IN|OUT')
   validate_re($ensure, 'absent|present')
-  validate_re($proto, 'tcp|udp')
+  validate_re($proto, 'tcp|udp|any')
   validate_string($from,
     $ip,
     $port

--- a/manifests/deny.pp
+++ b/manifests/deny.pp
@@ -22,7 +22,7 @@ define ufw::deny(
   $proto = 'tcp',
 ) {
   validate_re($direction, 'IN|OUT')
-  validate_re($proto, 'tcp|udp')
+  validate_re($proto, 'tcp|udp|any')
   validate_string($from,
     $ip,
     $port

--- a/manifests/reject.pp
+++ b/manifests/reject.pp
@@ -22,7 +22,7 @@ define ufw::reject(
   $proto = 'tcp',
 ) {
   validate_re($direction, 'IN|OUT')
-  validate_re($proto, 'tcp|udp')
+  validate_re($proto, 'tcp|udp|any')
   validate_string($from,
     $ip,
     $port

--- a/spec/defines/allow_spec.rb
+++ b/spec/defines/allow_spec.rb
@@ -34,11 +34,27 @@ describe 'ufw::allow', :type => :define do
       }
     end
 
+    context 'from $ip parameter (any protocol)' do
+      let(:params) { {:ip => '192.0.2.68'} }
+      it { should contain_exec('ufw-allow-IN-any-from-any-to-192.0.2.68-port-all').
+                   with_command("ufw allow  proto any from any to 192.0.2.68").
+                   with_unless("ufw status | grep -qE '^192.0.2.68 +ALLOW +Anywhere( +.*)?$'")
+      }
+    end
+
     context 'from $ip parameter (ipv6)' do
       let(:params) { {:ip => '2a00:1450:4009:80c::1001'} }
       it { should contain_exec('ufw-allow-IN-tcp-from-any-to-2a00:1450:4009:80c::1001-port-all').
         with_command("ufw allow  proto tcp from any to 2a00:1450:4009:80c::1001").
         with_unless("ufw status | grep -qE '^2a00:1450:4009:80c::1001/tcp +ALLOW +Anywhere \\(v6\\)( +.*)?$'")
+      }
+    end
+
+    context 'from $ip parameter (ipv6, any protocol)' do
+      let(:params) { {:ip => '2a00:1450:4009:80c::1001'} }
+      it { should contain_exec('ufw-allow-IN-any-from-any-to-2a00:1450:4009:80c::1001-port-all').
+                   with_command("ufw allow  proto any from any to 2a00:1450:4009:80c::1001").
+                   with_unless("ufw status | grep -qE '^2a00:1450:4009:80c::1001 +ALLOW +Anywhere \\(v6\\)( +.*)?$'")
       }
     end
 
@@ -66,6 +82,14 @@ describe 'ufw::allow', :type => :define do
     it { should contain_exec('ufw-allow-IN-tcp-from-any-to-192.168.42.42-port-8080').
       with_command("ufw allow  proto tcp from any to 192.168.42.42 port 8080").
       with_unless("ufw status | grep -qE '^192.168.42.42 8080/tcp +ALLOW +Anywhere( +.*)?$'")
+    }
+  end
+
+  context 'specifying port for any protocol' do
+    let(:params) { {:port => '8080'} }
+    it { should contain_exec('ufw-allow-IN-any-from-any-to-192.168.42.42-port-8080').
+                 with_command("ufw allow  proto any from any to 192.168.42.42 port 8080").
+                 with_unless("ufw status | grep -qE '^192.168.42.42 8080 +ALLOW +Anywhere( +.*)?$'")
     }
   end
 


### PR DESCRIPTION
we already have code for handling the `any` case, but our validation was
rejecting it long before it was hit.
n.b.: I don't know if this applies for `ufw::limit`, since it explicitly
limits a certain protocol.

This pull request addresses #54